### PR TITLE
MenuItemPolicy accesses key instead of name

### DIFF
--- a/src/Policies/MenuItemPolicy.php
+++ b/src/Policies/MenuItemPolicy.php
@@ -37,7 +37,7 @@ class MenuItemPolicy extends BasePolicy
         }
 
         // If permission doesn't exist, we can't check it!
-        if (!Voyager::model('Permission')->whereName('browse_'.$slug)->exists()) {
+        if (!Voyager::model('Permission')->whereKey('browse_'.$slug)->exists()) {
             return true;
         }
 


### PR DESCRIPTION
* MenuItemPolicy access now the key column instead of the name column from table permissions

* adjusted code to style guidelines

* made command more succinct